### PR TITLE
Add serializable attribute to EntityBase

### DIFF
--- a/src/Digipolis.DataAccess/Entities/EntityBase.cs
+++ b/src/Digipolis.DataAccess/Entities/EntityBase.cs
@@ -1,7 +1,9 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Digipolis.DataAccess.Entities
 {
+    [Serializable]
     public class EntityBase
     {
         // This is the base class for all entities.


### PR DESCRIPTION
For use in Distributed caching to Redis, entities need to be serialized into byte-arrays.
Since we would like to cache some database calls, the EntityBase class should be set to Serializable.